### PR TITLE
Some refactoring - Add confirm modal

### DIFF
--- a/app/admin/actions.ts
+++ b/app/admin/actions.ts
@@ -31,3 +31,10 @@ export async function removeParticipant(participant: Participant) {
 
   revalidatePath(`/admin/draws/${draw!.slug}`);
 }
+
+export async function getParticipant(id: number) {
+  const participant = await prisma.participant.findUnique({
+    where: { id },
+  });
+  return participant;
+}

--- a/app/admin/draws/[slug]/page.tsx
+++ b/app/admin/draws/[slug]/page.tsx
@@ -1,6 +1,5 @@
 import { auth } from "@/auth";
 import { redirect } from "next/navigation";
-import { ConfirmProvider } from "@/components/confirm/ConfirmProvider";
 import ParticipantList from "@/components/ParticipantList";
 import { getDrawBySlug } from "@/services/draws";
 import { getParticipants } from "@/services/participants";
@@ -22,21 +21,19 @@ export default async function AdminDrawPage({ params }: AdminDrawPageProps) {
   const participants = await getParticipants(draw);
 
   return (
-    <ConfirmProvider>
-      <div>
-        <h1 className="text-4xl">Participantes para el sorteo {draw.name}</h1>
-        <div className="pt-10">
-          {participants.length > 0 ? (
-            <ParticipantList participants={participants} slug={slug} />
-          ) : (
-            <EmptyView>Aún no hay participantes en éste sorteo</EmptyView>
-          )}
-        </div>
-        <div className="pt-8">
-          <h2 className="text-2xl">Agregar participante</h2>
-          <CreateParticipant draw={draw} />
-        </div>
+    <div>
+      <h1 className="text-4xl">Participantes para el sorteo {draw.name}</h1>
+      <div className="pt-10">
+        {participants.length > 0 ? (
+          <ParticipantList participants={participants} slug={slug} />
+        ) : (
+          <EmptyView>Aún no hay participantes en éste sorteo</EmptyView>
+        )}
       </div>
-    </ConfirmProvider>
+      <div className="pt-8">
+        <h2 className="text-2xl">Agregar participante</h2>
+        <CreateParticipant draw={draw} />
+      </div>
+    </div>
   );
 }

--- a/app/admin/draws/[slug]/page.tsx
+++ b/app/admin/draws/[slug]/page.tsx
@@ -1,9 +1,11 @@
 import { auth } from "@/auth";
 import { redirect } from "next/navigation";
+import { ConfirmProvider } from "@/components/confirm/ConfirmProvider";
 import ParticipantList from "@/components/ParticipantList";
 import { getDrawBySlug } from "@/services/draws";
 import { getParticipants } from "@/services/participants";
 import CreateParticipant from "@/components/CreateParticipant";
+import EmptyView from "@/components/EmptyView";
 
 interface AdminDrawPageProps {
   params: { slug: string };
@@ -20,21 +22,21 @@ export default async function AdminDrawPage({ params }: AdminDrawPageProps) {
   const participants = await getParticipants(draw);
 
   return (
-    <div>
-      <h1 className="text-4xl">Participantes para el sorteo {draw.name}</h1>
-      <div className="pt-10">
-        {participants.length > 0 ? (
-          <ParticipantList participants={participants} slug={slug} />
-        ) : (
-          <div className="w-full h-24 flex items-center justify-center border border-gray-400 rounded-2xl">
-            Aún no hay participantes en éste sorteo
-          </div>
-        )}
+    <ConfirmProvider>
+      <div>
+        <h1 className="text-4xl">Participantes para el sorteo {draw.name}</h1>
+        <div className="pt-10">
+          {participants.length > 0 ? (
+            <ParticipantList participants={participants} slug={slug} />
+          ) : (
+            <EmptyView>Aún no hay participantes en éste sorteo</EmptyView>
+          )}
+        </div>
+        <div className="pt-8">
+          <h2 className="text-2xl">Agregar participante</h2>
+          <CreateParticipant draw={draw} />
+        </div>
       </div>
-      <div className="pt-8">
-        <h2 className="text-2xl">Agregar participante</h2>
-        <CreateParticipant draw={draw} />
-      </div>
-    </div>
+    </ConfirmProvider>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,28 +1,46 @@
 @import "tailwindcss";
+@import "tw-animate-css";
 
-:root {
-  --background: #ffffff;
-  --foreground: #171717;
-}
+@custom-variant dark (&:is(.dark *));
 
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
-}
-
-body {
-  background: var(--background);
-  color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  --color-sidebar-ring: var(--sidebar-ring);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar: var(--sidebar);
+  --color-chart-5: var(--chart-5);
+  --color-chart-4: var(--chart-4);
+  --color-chart-3: var(--chart-3);
+  --color-chart-2: var(--chart-2);
+  --color-chart-1: var(--chart-1);
+  --color-ring: var(--ring);
+  --color-input: var(--input);
+  --color-border: var(--border);
+  --color-destructive: var(--destructive);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-accent: var(--accent);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-muted: var(--muted);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-secondary: var(--secondary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-primary: var(--primary);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-popover: var(--popover);
+  --color-card-foreground: var(--card-foreground);
+  --color-card: var(--card);
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
 }
 
 .color-switch {
@@ -35,5 +53,83 @@ body {
   }
   to {
     color: var(--color2);
+  }
+}
+
+:root {
+  --radius: 0.625rem;
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.145 0 0);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.145 0 0);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.145 0 0);
+  --primary: oklch(0.205 0 0);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.97 0 0);
+  --secondary-foreground: oklch(0.205 0 0);
+  --muted: oklch(0.97 0 0);
+  --muted-foreground: oklch(0.556 0 0);
+  --accent: oklch(0.97 0 0);
+  --accent-foreground: oklch(0.205 0 0);
+  --destructive: oklch(0.577 0.245 27.325);
+  --border: oklch(0.922 0 0);
+  --input: oklch(0.922 0 0);
+  --ring: oklch(0.708 0 0);
+  --chart-1: oklch(0.646 0.222 41.116);
+  --chart-2: oklch(0.6 0.118 184.704);
+  --chart-3: oklch(0.398 0.07 227.392);
+  --chart-4: oklch(0.828 0.189 84.429);
+  --chart-5: oklch(0.769 0.188 70.08);
+  --sidebar: oklch(0.985 0 0);
+  --sidebar-foreground: oklch(0.145 0 0);
+  --sidebar-primary: oklch(0.205 0 0);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.97 0 0);
+  --sidebar-accent-foreground: oklch(0.205 0 0);
+  --sidebar-border: oklch(0.922 0 0);
+  --sidebar-ring: oklch(0.708 0 0);
+}
+
+.dark {
+  --background: oklch(0.145 0 0);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.205 0 0);
+  --card-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.205 0 0);
+  --popover-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.922 0 0);
+  --primary-foreground: oklch(0.205 0 0);
+  --secondary: oklch(0.269 0 0);
+  --secondary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.269 0 0);
+  --muted-foreground: oklch(0.708 0 0);
+  --accent: oklch(0.269 0 0);
+  --accent-foreground: oklch(0.985 0 0);
+  --destructive: oklch(0.704 0.191 22.216);
+  --border: oklch(1 0 0 / 10%);
+  --input: oklch(1 0 0 / 15%);
+  --ring: oklch(0.556 0 0);
+  --chart-1: oklch(0.488 0.243 264.376);
+  --chart-2: oklch(0.696 0.17 162.48);
+  --chart-3: oklch(0.769 0.188 70.08);
+  --chart-4: oklch(0.627 0.265 303.9);
+  --chart-5: oklch(0.645 0.246 16.439);
+  --sidebar: oklch(0.205 0 0);
+  --sidebar-foreground: oklch(0.985 0 0);
+  --sidebar-primary: oklch(0.488 0.243 264.376);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.269 0 0);
+  --sidebar-accent-foreground: oklch(0.985 0 0);
+  --sidebar-border: oklch(1 0 0 / 10%);
+  --sidebar-ring: oklch(0.556 0 0);
+}
+
+@layer base {
+  * {
+    @apply border-border outline-ring/50;
+  }
+  body {
+    @apply bg-background text-foreground;
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import "./globals.css";
 import "@radix-ui/themes/styles.css";
 import { ReactNode } from "react";
+import { ConfirmProvider } from "@/components/confirm/ConfirmProvider";
 
 export const metadata = {
   title: "Secret Santa",
@@ -11,9 +12,11 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="es">
       <body>
-        <main className="min-h-screen bg-gray-50 text-gray-900">
-          <div className="max-w-3xl mx-auto p-4">{children}</div>
-        </main>
+        <ConfirmProvider>
+          <main className="min-h-screen bg-gray-50 text-gray-900">
+            <div className="max-w-3xl mx-auto p-4">{children}</div>
+          </main>
+        </ConfirmProvider>
       </body>
     </html>
   );

--- a/components.json
+++ b/components.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "new-york",
+  "rsc": true,
+  "tsx": true,
+  "tailwind": {
+    "config": "",
+    "css": "app/globals.css",
+    "baseColor": "neutral",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "iconLibrary": "lucide",
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
+  },
+  "registries": {}
+}

--- a/components/DrawButton.tsx
+++ b/components/DrawButton.tsx
@@ -1,4 +1,4 @@
-import { Draw, Participant } from "@prisma/client";
+import { Participant } from "@prisma/client";
 import { useState } from "react";
 
 interface DrawButtonProps {
@@ -24,7 +24,6 @@ export default function DrawButton({
     });
     const json = await res.json();
     if (res.ok) {
-      console.log("Assigned to ->", json.assignedTo);
       onSelect(json.assignedTo as Participant);
     } else {
       alert(json.error || "Error");

--- a/components/DrawComponent.tsx
+++ b/components/DrawComponent.tsx
@@ -1,0 +1,55 @@
+"use client";
+import { useState, useEffect } from "react";
+import { Participant } from "@prisma/client";
+import DrawButton from "./DrawButton";
+import RevealTarget from "./RevealTarget";
+import { getParticipant } from "@/app/admin/actions";
+
+interface DrawComponentProps {
+  currentParticipant: Participant;
+  slug: string;
+}
+
+export default function DrawComponent({
+  currentParticipant,
+  slug,
+}: DrawComponentProps) {
+  const [target, setTarget] = useState<Participant | undefined>();
+
+  useEffect(() => {
+    async function fetchParticipant() {
+      if (!currentParticipant?.assignedTo) return;
+      const p = await getParticipant(currentParticipant.assignedTo);
+      if (p) {
+        setTarget(p);
+      }
+    }
+    fetchParticipant();
+  }, [currentParticipant.assignedTo]);
+
+  const handleSelect = (p: Participant) => {
+    setTarget(p);
+  };
+
+  return (
+    <>
+      {!currentParticipant?.assignedTo && (
+        <>
+          <p>
+            Por favor, para elegir a tu amigo invisible, presioná{" "}
+            <strong>Sortear</strong>.
+          </p>
+          <DrawButton
+            slug={slug as string}
+            drawer={currentParticipant as Participant}
+            onSelect={handleSelect}
+          />
+        </>
+      )}
+
+      <div id="animation-root" className="mt-6">
+        {!!target && <RevealTarget target={target.name} />}
+      </div>
+    </>
+  );
+}

--- a/components/EmptyView.tsx
+++ b/components/EmptyView.tsx
@@ -1,0 +1,19 @@
+import cx from "classnames";
+
+interface EmptyViewProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export default function EmptyView({ children, className }: EmptyViewProps) {
+  return (
+    <div
+      className={cx(
+        "w-full h-24 flex items-center justify-center border border-gray-400 rounded-2xl",
+        className ?? ""
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/components/ParticipantList.tsx
+++ b/components/ParticipantList.tsx
@@ -4,6 +4,8 @@ import { useTransition } from "react";
 import { FaRegTrashAlt } from "react-icons/fa";
 import { Participant } from "@prisma/client";
 import { removeParticipant } from "@/app/admin/actions";
+import { FaCheck } from "react-icons/fa6";
+import { useConfirm } from "./confirm/ConfirmProvider";
 
 interface ParticipantListProps {
   participants: Participant[];
@@ -14,14 +16,21 @@ export default function ParticipantList({
   participants,
   slug,
 }: ParticipantListProps) {
+  const confirm = useConfirm();
   const [isPending, startTransition] = useTransition();
 
-  console.log("PATH ->", window.location.origin);
-
   async function handleRemove(participant: Participant) {
-    startTransition(async () => {
-      await removeParticipant(participant);
+    const ok = await confirm({
+      title: "Eliminar participante",
+      description: `Se eliminará el participante ${participant.name}. Estás seguro?`,
+      confirmLabel: "Eliminar",
+      cancelLabel: "Cancelar",
     });
+    if (ok) {
+      startTransition(async () => {
+        await removeParticipant(participant);
+      });
+    }
   }
   return (
     <div>
@@ -32,6 +41,7 @@ export default function ParticipantList({
               Nombre
             </th>
             <th>Link</th>
+            <th>Sorteó?</th>
             <th className="p-4 border-b border-blue-gray-100 bg-blue-gray-50 text-right rounded-tr-xl">
               Acciones
             </th>
@@ -45,7 +55,18 @@ export default function ParticipantList({
             >
               <td className="p-4">{participant.name}</td>
               <td className="p-4">
-                {window.location.origin}/draw/{slug}/{participant.uuid}
+                {!!window && (
+                  <>
+                    {window?.location?.origin}/draw/{slug}/{participant.uuid}
+                  </>
+                )}
+              </td>
+              <td className="" align="center">
+                {!!participant.assignedTo && (
+                  <div className="bg-green-600 inline-block rounded-full p-1">
+                    <FaCheck color="white" size={12} />
+                  </div>
+                )}
               </td>
               <td className="p-4 flex pr-10 justify-end">
                 <button

--- a/components/ParticipantList.tsx
+++ b/components/ParticipantList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useTransition } from "react";
+import { useTransition, useState, useEffect } from "react";
 import { FaRegTrashAlt } from "react-icons/fa";
 import { Participant } from "@prisma/client";
 import { removeParticipant } from "@/app/admin/actions";
@@ -18,6 +18,12 @@ export default function ParticipantList({
 }: ParticipantListProps) {
   const confirm = useConfirm();
   const [isPending, startTransition] = useTransition();
+  const [origin, setOrigin] = useState("");
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setOrigin(window.location.origin);
+  }, []);
 
   async function handleRemove(participant: Participant) {
     const ok = await confirm({
@@ -32,6 +38,7 @@ export default function ParticipantList({
       });
     }
   }
+
   return (
     <div>
       <table className="w-full text-left table-auto min-w-max">
@@ -55,9 +62,9 @@ export default function ParticipantList({
             >
               <td className="p-4">{participant.name}</td>
               <td className="p-4">
-                {!!window && (
+                {!!origin && (
                   <>
-                    {window?.location?.origin}/draw/{slug}/{participant.uuid}
+                    {origin}/draw/{slug}/{participant.uuid}
                   </>
                 )}
               </td>

--- a/components/confirm/ConfirmDialog.tsx
+++ b/components/confirm/ConfirmDialog.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+interface Props {
+  open: boolean;
+  title: string;
+  description?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function ConfirmDialog({
+  open,
+  title,
+  description,
+  confirmLabel = "Confirmar",
+  cancelLabel = "Cancelar",
+  onConfirm,
+  onCancel,
+}: Props) {
+  return (
+    <AlertDialog open={open}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          {description && (
+            <AlertDialogDescription>{description}</AlertDialogDescription>
+          )}
+        </AlertDialogHeader>
+
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={onCancel}>
+            {cancelLabel}
+          </AlertDialogCancel>
+          <AlertDialogAction onClick={onConfirm}>
+            {confirmLabel}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/components/confirm/ConfirmProvider.tsx
+++ b/components/confirm/ConfirmProvider.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useRef,
+  useState,
+} from "react";
+import { ConfirmDialog } from "./ConfirmDialog";
+
+type ConfirmOptions = {
+  title: string;
+  description?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+};
+
+type ConfirmFn = (options: ConfirmOptions) => Promise<boolean>;
+
+const ConfirmContext = createContext<ConfirmFn | null>(null);
+
+export function useConfirm() {
+  const ctx = useContext(ConfirmContext);
+  if (!ctx) throw new Error("useConfirm must be used inside ConfirmProvider");
+  return ctx;
+}
+
+export function ConfirmProvider({ children }: { children: React.ReactNode }) {
+  const [open, setOpen] = useState(false);
+  const resolveRef = useRef<(value: boolean) => void>(() => {});
+  const [options, setOptions] = useState<ConfirmOptions>({
+    title: "",
+    description: "",
+  });
+
+  const confirm: ConfirmFn = useCallback((opts) => {
+    setOptions(opts);
+    setOpen(true);
+
+    return new Promise<boolean>((resolve) => {
+      resolveRef.current = resolve;
+    });
+  }, []);
+
+  const handleConfirm = () => {
+    resolveRef.current(true);
+    setOpen(false);
+  };
+
+  const handleCancel = () => {
+    resolveRef.current(false);
+    setOpen(false);
+  };
+
+  return (
+    <ConfirmContext.Provider value={confirm}>
+      {children}
+
+      <ConfirmDialog
+        open={open}
+        title={options.title}
+        description={options.description}
+        confirmLabel={options.confirmLabel}
+        cancelLabel={options.cancelLabel}
+        onConfirm={handleConfirm}
+        onCancel={handleCancel}
+      />
+    </ConfirmContext.Provider>
+  );
+}

--- a/components/ui/alert-dialog.tsx
+++ b/components/ui/alert-dialog.tsx
@@ -1,0 +1,157 @@
+"use client"
+
+import * as React from "react"
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+
+import { cn } from "@/lib/utils"
+import { buttonVariants } from "@/components/ui/button"
+
+function AlertDialog({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+}
+
+function AlertDialogTrigger({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return (
+    <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+  )
+}
+
+function AlertDialogPortal({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return (
+    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+  )
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="alert-dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          className
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  )
+}
+
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn("text-lg font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogAction({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
+  return (
+    <AlertDialogPrimitive.Action
+      className={cn(buttonVariants(), className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogCancel({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
+  return (
+    <AlertDialogPrimitive.Cancel
+      className={cn(buttonVariants({ variant: "outline" }), className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,0 +1,60 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+        outline:
+          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost:
+          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-9 px-4 py-2 has-[>svg]:px-3",
+        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
+        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+        icon: "size-9",
+        "icon-sm": "size-8",
+        "icon-lg": "size-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+function Button({
+  className,
+  variant,
+  size,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"button"> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean
+  }) {
+  const Comp = asChild ? Slot : "button"
+
+  return (
+    <Comp
+      data-slot="button"
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  )
+}
+
+export { Button, buttonVariants }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,15 @@
       "dependencies": {
         "@auth/prisma-adapter": "^2.11.1",
         "@prisma/client": "^6.19.0",
+        "@radix-ui/react-alert-dialog": "^1.1.15",
+        "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/themes": "^3.2.1",
         "autoprefixer": "^10.4.21",
+        "class-variance-authority": "^0.7.1",
+        "classnames": "^2.5.1",
+        "clsx": "^2.1.1",
         "framer-motion": "^12.23.24",
+        "lucide-react": "^0.553.0",
         "next": "16.0.1",
         "next-auth": "^5.0.0-beta.30",
         "postcss": "^8.5.6",
@@ -21,6 +27,7 @@
         "react-dom": "19.2.0",
         "react-icons": "^5.5.0",
         "sqlite3": "^5.1.7",
+        "tailwind-merge": "^3.4.0",
         "uuid": "^13.0.0"
       },
       "devDependencies": {
@@ -32,6 +39,7 @@
         "eslint-config-next": "16.0.1",
         "tailwindcss": "^4.1.17",
         "tsx": "^4.20.6",
+        "tw-animate-css": "^1.4.0",
         "typescript": "^5"
       }
     },
@@ -1892,6 +1900,23 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-arrow": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
@@ -2045,6 +2070,23 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-collection/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
@@ -2131,6 +2173,23 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -2376,6 +2435,23 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-menubar": {
       "version": "1.1.16",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-menubar/-/react-menubar-1.1.16.tgz",
@@ -2540,6 +2616,23 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-popper": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
@@ -2635,6 +2728,23 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -2795,6 +2905,23 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-separator": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.7.tgz",
@@ -2850,9 +2977,9 @@
       }
     },
     "node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
+      "integrity": "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.2"
       },
@@ -3065,6 +3192,23 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -4849,6 +4993,17 @@
         "consola": "^3.2.3"
       }
     },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
     "node_modules/classnames": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
@@ -4867,6 +5022,14 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -7488,6 +7651,14 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "0.553.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.553.0.tgz",
+      "integrity": "sha512-BRgX5zrWmNy/lkVAe0dXBgd7XQdZ3HTf+Hwe3c9WK6dqgnj9h+hxV+MDncM88xDWlCq27+TKvHGE70ViODNILw==",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -8595,6 +8766,23 @@
         }
       }
     },
+    "node_modules/radix-ui/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -9543,6 +9731,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tailwind-merge": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.4.0.tgz",
+      "integrity": "sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "4.1.17",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.17.tgz",
@@ -9756,6 +9953,15 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/tw-animate-css": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/tw-animate-css/-/tw-animate-css-1.4.0.tgz",
+      "integrity": "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/Wombosvideo"
       }
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -12,9 +12,15 @@
   "dependencies": {
     "@auth/prisma-adapter": "^2.11.1",
     "@prisma/client": "^6.19.0",
+    "@radix-ui/react-alert-dialog": "^1.1.15",
+    "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/themes": "^3.2.1",
     "autoprefixer": "^10.4.21",
+    "class-variance-authority": "^0.7.1",
+    "classnames": "^2.5.1",
+    "clsx": "^2.1.1",
     "framer-motion": "^12.23.24",
+    "lucide-react": "^0.553.0",
     "next": "16.0.1",
     "next-auth": "^5.0.0-beta.30",
     "postcss": "^8.5.6",
@@ -23,6 +29,7 @@
     "react-dom": "19.2.0",
     "react-icons": "^5.5.0",
     "sqlite3": "^5.1.7",
+    "tailwind-merge": "^3.4.0",
     "uuid": "^13.0.0"
   },
   "devDependencies": {
@@ -34,6 +41,7 @@
     "eslint-config-next": "16.0.1",
     "tailwindcss": "^4.1.17",
     "tsx": "^4.20.6",
+    "tw-animate-css": "^1.4.0",
     "typescript": "^5"
   }
 }


### PR DESCRIPTION
## Draw page Refactor
- Cambié la [página del sorteo](app/draw/[slug]/[uuid]/page.tsx) (donde el usuario final sortea su amigo invisible) para que sea server-side, y pasé toda la lógica que se tiene que manejar del lado del cliente a un nuevo componente `DrawComponent`. Nota: siempre que se necesite interacción en tiempo de ejecución, con el browser, el componente tiene que ser client-side, ya que el servidor no puede manejarlo.
- Armé un componente aparte para el "Empty view", que nos va a ser de utilidad en los listados o componentes donde no tengamos data para mostrar.

## Improvement en el listado de participantes (admin)
- Se agregó la columna `Sorteó?`, donde podemos ver qué participantes sortearon y cuales todavía no. Esto nos permite tener una visibilidad del estado del sorteo en general sin saber quién sorteó a quién.
 
<img width="831" height="417" alt="image" src="https://github.com/user-attachments/assets/ce9cd215-e601-4877-8aed-d16dde6612bb" />

## Confirm component
Para el confirm (y de ahora en más, otros componentes visuales - igual lo charlamos), agregué la dependencia schadcn -> https://ui.shadcn.com/
Lo interesante de ésta librería es que te genera los componentes en el código de la app. Lo que nos permite customizarlos al 100% y no depender de diseños de terceros.
Estos componentes se generan automáticamente en `components/ui`.

Para poder usarlo fácilmente cuando lo necesitemos, armé un `ConfirmProvider`, donde se maneja todo el contexto de los confirm modal. Entonces, cuando lo necesitamos simplemente hacemos:

```ts
const ok = await confirm({
    title: "Eliminar participante",
    description: `Se eliminará el participante ${participant.name}. Estás seguro?`,
    confirmLabel: "Eliminar",
    cancelLabel: "Cancelar",
  });
```

También vas a ver cambios en `globals.css` y un nuevo archivo `components.json`. Esos también son generados por Schadcn